### PR TITLE
The position of the item in the table didn't match the key sometimes

### DIFF
--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -2,16 +2,24 @@ import styles from 'styles/table.module.css';
 
 type RowProps = {
   item: Record<string, unknown>;
+  keys: string[];
 };
 
-const Row = ({ item }: RowProps) => {
+const Row = ({ item, keys }: RowProps) => {
   const values: React.ReactNode[] = [];
-  for (const key of Object.keys(item)) {
-    values.push(
-      <td key={key} className={styles.row}>
-        {String(item[key])}
-      </td>
-    );
+  for (const key of keys) {
+    if (key in item) {
+      values.push(
+        <td key={key} className={styles.row}>
+          {String(item[key])}
+        </td>
+      );
+    } else {
+      values.push(
+        <td key={key} className={styles.row} />
+      );
+    }
+    
   }
   return <tr>{values}</tr>;
 };

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -22,7 +22,6 @@ const Table = ({ name, contents }: TableProps) => {
       for (const key of Object.keys(item)) {
         keys.add(key);
       }
-      rows.push(<Row key={count} item={item} />);
     } else if (isArray(item)) {
       const thisRow: React.ReactNode[] = [];
       for (const col of item) {
@@ -45,6 +44,16 @@ const Table = ({ name, contents }: TableProps) => {
 
   if (titleRowRequired) {
     rows.unshift(<TitleRow key={'title'} keys={Array.from(keys)} />);
+    
+    count = 0;
+    for (const item of contents) {
+      if (isDict(item)) {
+        rows.push(<Row key={count} item={item} keys={Array.from(keys)} />);
+      }
+
+      count += 1;
+    }
+
   }
 
   return (


### PR DESCRIPTION
When testing the TOML file editor, this is what participants complained most about.

On the current TOML file editor, the table requires the key-value pairs to be in the same order to present the information correctly. With this small patch, the TOML file editor now looks at the column's key to pick the value.